### PR TITLE
start.w.sh: tweaks

### DIFF
--- a/root-scripts/start.w.sh
+++ b/root-scripts/start.w.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
-cd "$(dirname "$(readlink -f "$0")")" || exit; [ "$EUID" = "0" ] && exit; export R="$PWD"; DWRFST="$R/dwarfsettings.sh"; RMT="$PWD/files/rumtricks.sh"; WHA="$PWD/files/wha.sh"; 
+cd "$(dirname "$(readlink -f "$0")")" || exit; [ "$EUID" = "0" ] && exit; export R="$PWD"; DWRFST="$R/dwarfsettings.sh"; RMT="$PWD/files/rumtricks.sh"; WHA="$PWD/files/wha.sh";
 [ ! -e "$RMT" ] && cp /usr/bin/rumtricks "$RMT"; [ ! -e "$WHA" ] && cp /usr/bin/wha "$WHA"; export WINE_LARGE_ADDRESS_AWARE=1;
-export WINEFSYNC=1; export WINEDLLOVERRIDES="mscoree=d;mshtml=d;"; 
+export WINEFSYNC=1; export WINEDLLOVERRIDES="mscoree=d;mshtml=d;";
 export BINDIR="$PWD/files/groot"; BIN="game.exe";
-export WINE="$(command -v wine)"; [ ! -x "$WINE" ] && export WINE="$BINDIR/wine/bin/wine"; CMD=("$WINE" "$BIN");
+export WINE="$(command -v wine-tkg || command -v wine-ge || command -v wine-tkg-nomingw )"; [ ! -x "$WINE" ] && export WINE="$BINDIR/wine/bin/wine"; bash "$WHA" "$(basename $WINE)"; CMD=("$WINE" "$BIN");
 
 # gamescope/FSR
 : ${GAMESCOPE:=$(command -v gamescope)}; [ -x "$GAMESCOPE" ] && CMD=("$GAMESCOPE" -f -- "${CMD[@]}");
-
-# Custom WINE (wine-tkg, wine-ge, wine-tkg-nomingw)
-CWINE="wine-tkg"; bash "$WHA" "$CWINE"
 
 # dwarfs
 bash "$DWRFST" mount-game; bash "$DWRFST" mount-prefix;
@@ -43,3 +40,4 @@ EOF
 echo -e "\e[0m"
 [ "${DBG:=0}" = "1" ] || exec &>/dev/null
 cd "$BINDIR"; "${CMD[@]}" "$@"
+

--- a/root-scripts/start.w.sh
+++ b/root-scripts/start.w.sh
@@ -3,17 +3,15 @@ cd "$(dirname "$(readlink -f "$0")")" || exit; [ "$EUID" = "0" ] && exit; export
 [ ! -e "$RMT" ] && cp /usr/bin/rumtricks "$RMT"; [ ! -e "$WHA" ] && cp /usr/bin/wha "$WHA"; export WINE_LARGE_ADDRESS_AWARE=1;
 export WINEFSYNC=1; export WINEDLLOVERRIDES="mscoree=d;mshtml=d;";
 export BINDIR="$PWD/files/groot"; BIN="game.exe";
-export WINE="$(command -v wine)" || export WINE="$BINDIR/wine/bin/wine"; CMD=("$WINE" "$BIN");
 
-# WINE handler
-_WINE="$(command -v wine-tkg || command -v wine-ge || command -v wine-tkg-nomingw )"; [ -x "$_WINE" ] && bash "$WHA" "$(basename $_WINE)"
+# WINE handler (choices: wine-tkg, wine-ge, wine-tkg-nomingw)
+_WINE="wine-tkg"; bash "$WHA" "$_WINE"; [ -x "$BINDIR/wine/bin/wine" ] && export WINE="$BINDIR/wine/bin/wine" || export WINE="$(command -v wine)"; CMD=("$WINE" "$BIN");
 
 # gamescope/FSR
 : ${GAMESCOPE:=$(command -v gamescope)}; [ -x "$GAMESCOPE" ] && CMD=("$GAMESCOPE" -f -- "${CMD[@]}");
 
 # dwarfs
-bash "$DWRFST" mount-game; bash "$DWRFST" mount-prefix;
-export WINEPREFIX="$PWD/files/data/prefix-tmp"
+bash "$DWRFST" mount-game; bash "$DWRFST" mount-prefix; export WINEPREFIX="$PWD/files/data/prefix-tmp"
 
 # Rumtricks
 bash "$RMT" isolation

--- a/root-scripts/start.w.sh
+++ b/root-scripts/start.w.sh
@@ -3,7 +3,10 @@ cd "$(dirname "$(readlink -f "$0")")" || exit; [ "$EUID" = "0" ] && exit; export
 [ ! -e "$RMT" ] && cp /usr/bin/rumtricks "$RMT"; [ ! -e "$WHA" ] && cp /usr/bin/wha "$WHA"; export WINE_LARGE_ADDRESS_AWARE=1;
 export WINEFSYNC=1; export WINEDLLOVERRIDES="mscoree=d;mshtml=d;";
 export BINDIR="$PWD/files/groot"; BIN="game.exe";
-export WINE="$(command -v wine-tkg || command -v wine-ge || command -v wine-tkg-nomingw )"; [ ! -x "$WINE" ] && export WINE="$BINDIR/wine/bin/wine"; bash "$WHA" "$(basename $WINE)"; CMD=("$WINE" "$BIN");
+export WINE="$(command -v wine)" || export WINE="$BINDIR/wine/bin/wine"; CMD=("$WINE" "$BIN");
+
+# WINE handler
+_WINE="$(command -v wine-tkg || command -v wine-ge || command -v wine-tkg-nomingw )"; [ -x "$_WINE" ] && bash "$WHA" "$(basename $_WINE)"
 
 # gamescope/FSR
 : ${GAMESCOPE:=$(command -v gamescope)}; [ -x "$GAMESCOPE" ] && CMD=("$GAMESCOPE" -f -- "${CMD[@]}");

--- a/root-scripts/start.w.sh
+++ b/root-scripts/start.w.sh
@@ -3,17 +3,24 @@ cd "$(dirname "$(readlink -f "$0")")" || exit; [ "$EUID" = "0" ] && exit; export
 [ ! -e "$RMT" ] && cp /usr/bin/rumtricks "$RMT"; [ ! -e "$WHA" ] && cp /usr/bin/wha "$WHA"; export WINE_LARGE_ADDRESS_AWARE=1;
 export WINEFSYNC=1; export WINEDLLOVERRIDES="mscoree=d;mshtml=d;"; 
 export BINDIR="$PWD/files/groot"; BIN="game.exe";
-[ -x "/bin/wine-tkg" ] && export WINE="$(command -v wine)" || export WINE="$BINDIR/wine/bin/wine"; CMD=("$WINE" "$BIN");
+export WINE="$(command -v wine)"; [ ! -x "$WINE" ] && export WINE="$BINDIR/wine/bin/wine"; CMD=("$WINE" "$BIN");
 
 # gamescope/FSR
 : ${GAMESCOPE:=$(command -v gamescope)}; [ -x "$GAMESCOPE" ] && CMD=("$GAMESCOPE" -f -- "${CMD[@]}");
 
+# Custom WINE (wine-tkg, wine-ge, wine-tkg-nomingw)
+CWINE="wine-tkg"; bash "$WHA" "$CWINE"
+
 # dwarfs
-bash "$DWRFST" mount-game; bash "$WHA" wine-tkg; bash "$DWRFST" mount-prefix;
+bash "$DWRFST" mount-game; bash "$DWRFST" mount-prefix;
+export WINEPREFIX="$PWD/files/data/prefix-tmp"
+
+# Rumtricks
+bash "$RMT" isolation
+
+# Cleanup (runs when game exits/crashes)
 function cleanup { cd "$OLDPWD" && bash "$DWRFST" unmount-prefix unmount-game; }
 trap 'cleanup' EXIT SIGINT SIGTERM
-
-export WINEPREFIX="$PWD/files/data/prefix-tmp"; bash "$RMT" isolation
 
 echo -e "\e[38;5;$((RANDOM%257))m" && cat << 'EOF'
                      ⣐⢕⢕⢕⢕⢕⢕⢕⢕⠅⢗⢕⢕⢕⢕⢕⢕⢕⠕⠕⢕⢕⢕⢕⢕⢕⢕⢕⢕


### PR DESCRIPTION
- revamped WINE handler logic (now with a choice of custom WINE builds!)
- Rumtricks line gets it's own "section" (so more tricks can be added as per need)
- Cleanup trap gets it's own section (for extending the cleanup function, like for older games which use fluidsynth for MIDI sounds)