### PR TITLE
fix dependency package name

### DIFF
--- a/setup/fedora.md
+++ b/setup/fedora.md
@@ -17,7 +17,7 @@ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-rele
 
 #### other libraries
 ```sh
-sudo dnf install libxcrypt zlib alsa-lib alsa-plugins fluidsynth pulseaudio openal
+sudo dnf install libxcrypt zlib alsa-lib alsa-plugins-pulseaudio fluidsynth pulseaudio openal
 ```
 
 <br><br>
@@ -44,5 +44,5 @@ Add `nvidia-drm.modeset=1` as a kernel parameter for the best results.
 
 #### other libraries
 ```sh
-rpm-ostree install libxcrypt zlib alsa-lib alsa-plugins fluidsynth pulseaudio openal --apply-live
+rpm-ostree install libxcrypt zlib alsa-lib alsa-plugins-pulseaudio fluidsynth pulseaudio openal --apply-live
 ```


### PR DESCRIPTION
`alsa-plugins` dependency does not exist, the ones available are listed here (dnf search alsa-plugins):

```sh
alsa-plugins-arcamav.i686 : Arcam AV amplifier plugin for ALSA
alsa-plugins-arcamav.x86_64 : Arcam AV amplifier plugin for ALSA
alsa-plugins-freeworld-a52.x86_64 : A52 output plugin using libavcodec
alsa-plugins-freeworld-lavrate.x86_64 : Rate converter plugin using libavcodec
alsa-plugins-jack.i686 : Jack PCM output plugin for ALSA
alsa-plugins-jack.x86_64 : Jack PCM output plugin for ALSA
alsa-plugins-maemo.i686 : Maemo plugin for ALSA
alsa-plugins-maemo.x86_64 : Maemo plugin for ALSA
alsa-plugins-oss.i686 : Oss PCM output plugin for ALSA
alsa-plugins-oss.x86_64 : Oss PCM output plugin for ALSA
alsa-plugins-pulseaudio.i686 : Alsa to PulseAudio backend
alsa-plugins-pulseaudio.x86_64 : Alsa to PulseAudio backend
alsa-plugins-samplerate.i686 : External rate converter plugin for ALSA
alsa-plugins-samplerate.x86_64 : External rate converter plugin for ALSA
alsa-plugins-speex.i686 : Rate Converter Plugin Using Speex Resampler
alsa-plugins-speex.x86_64 : Rate Converter Plugin Using Speex Resampler
alsa-plugins-upmix.i686 : Upmixer channel expander plugin for ALSA
alsa-plugins-upmix.x86_64 : Upmixer channel expander plugin for ALSA
alsa-plugins-usbstream.i686 : USB stream plugin for ALSA
alsa-plugins-usbstream.x86_64 : USB stream plugin for ALSA
alsa-plugins-vdownmix.i686 : Downmixer to stereo plugin for ALSA
alsa-plugins-vdownmix.x86_64 : Downmixer to stereo plugin for ALSA
```

I assumed `alsa-plugins-pulseaudio` is the one since `pulseaudio` is another dependency